### PR TITLE
Add missing curly brace to `to_form/2` deprecation warning

### DIFF
--- a/lib/phoenix_component.ex
+++ b/lib/phoenix_component.ex
@@ -1461,7 +1461,7 @@ defmodule Phoenix.Component do
 
       You might do:
 
-          <.form :let={f} for={%{}} as={#{inspect(data)} ...>
+          <.form :let={f} for={%{}} as={#{inspect(data)}} ...>
 
       Or, if you prefer, use to_form to create a form in your LiveView:
 


### PR DESCRIPTION
The relevant portion of the deprecation warning for `to_form/2` displays as follows on the console:

```
You might do:

    <.form :let={f} for={%{}} as={:user ...>
```

This PR includes the missing curly brace for the `as` attribute.